### PR TITLE
Fix POD formatting

### DIFF
--- a/lib/OX/RouteBuilder/REST.pm
+++ b/lib/OX/RouteBuilder/REST.pm
@@ -142,8 +142,8 @@ defaults for the route, as well as C<name> (which will be set to
 C<"REST.$controller.$action">).
 
 To generate a link to an action, use C<uri_for> with either the name
-(eg C<"REST.$controller.$action">), or by passing a HashRef C<{
-    controller => $controller, action => $action }>. See F<t/test.t>
+(eg C<"REST.$controller.$action">), or by passing a HashRef C<<{
+    controller => $controller, action => $action }>>. See F<t/test.t>
     for some examples.
 
 


### PR DESCRIPTION
If the thing inside has a > you need to use more <<>> to escape it.  This made the docs on the metacpan less than idea.